### PR TITLE
Package Manager Detection based on Distro

### DIFF
--- a/install
+++ b/install
@@ -6,7 +6,15 @@ echo
 # install build dependencies
 #
 ##################
-sudo apt-get install nodejs git build-essential
+if [ -f /etc/debian_version ]; then 
+    sudo apt-get install nodejs git build-essential
+elif [ -f /etc/redhat-release ]; then 
+    sudo dnf groupinstall "Development Tools"
+    sudo dnf install nodejs
+else 
+    echo "Try installing packages manually. Not a deb / rpm based distribution"
+    exit
+fi
 
 
 echo "#1 Build Source"


### PR DESCRIPTION
Updated the install script to check for debian or redhat based distro and use the appropriate package manager to install the build essentials / development tools.
